### PR TITLE
[Add] OMOP Extension Skeleton: Activates with DataFrames.jl and OMOPCommonDataModel.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,11 +10,9 @@ OMOPCommonDataModel = "ba65db9e-6590-4054-ab8a-101ed9124986"
 
 [extensions]
 HealthBaseDrWatsonExt = "DrWatson"
-HealthBaseOMOPExt = ["DataFrames", "OMOPCommonDataModel"]
+HealthBaseOMOPCDMExt = ["DataFrames", "OMOPCommonDataModel"]
 
 [compat]
-DataFrames = "1.7.0"
-OMOPCommonDataModel = "0.1.4"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,16 @@ version = "2.0.0"
 
 [weakdeps]
 DrWatson = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+OMOPCommonDataModel = "ba65db9e-6590-4054-ab8a-101ed9124986"
 
 [extensions]
 HealthBaseDrWatsonExt = "DrWatson"
+HealthBaseOMOPExt = ["DataFrames", "OMOPCommonDataModel"]
 
 [compat]
+DataFrames = "1.7.0"
+OMOPCommonDataModel = "0.1.4"
 julia = "1.10"
 
 [extras]

--- a/ext/HealthBaseOMOPCDMExt.jl
+++ b/ext/HealthBaseOMOPCDMExt.jl
@@ -1,4 +1,4 @@
-module HealthBaseOMOPExt
+module HealthBaseOMOPCDMExt
 
 using HealthBase
 using DataFrames

--- a/ext/HealthBaseOMOPExt.jl
+++ b/ext/HealthBaseOMOPExt.jl
@@ -1,0 +1,9 @@
+module HealthBaseOMOPExt
+
+using HealthBase
+using DataFrames
+using OMOPCommonDataModel
+
+__init__() = @info "OMOP extension for HealthBase has been loaded!"
+
+end


### PR DESCRIPTION
This PR adds a new extension module, `HealthBaseOMOPExt`, to HealthBase.jl. The extension is designed to activate only when both `DataFrames.jl` and `OMOPCommonDataModel.jl` are loaded, following the extension pattern used for DrWatson.