### PR TITLE
ENH: Improve HealthTable display with summary and OMOP version

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -14,6 +14,10 @@ This method is purely for display; it returns `nothing`.
 """
 function Base.show(io::IO, ht::HealthTable)
     df = ht.source
+    
+    rows, cols = size(df)
+    ver = haskey(metadata(df), "omop_cdm_version") ? " (OMOP $(metadata(df, "omop_cdm_version")))" : ""
+    println(io, "HealthTable$ver: $rows rows × $cols columns")
 
     if nrow(df) == 0
         pretty_table(io, ["HealthTable is empty"]; header = [""])
@@ -22,8 +26,8 @@ function Base.show(io::IO, ht::HealthTable)
     end
 
     if haskey(metadata(df), "omop_cdm_version")
-        println(io, "\nOMOP CDM version: ", metadata(df, "omop_cdm_version"))
+        println(io, "OMOP CDM version: ", metadata(df, "omop_cdm_version"))
     end
-
+    
     return nothing
 end


### PR DESCRIPTION
feat(ui): improve HealthTable show() output with summary and OMOP version

Enhances the display of `HealthTable` when printed in the REPL or notebooks
by adding a concise summary line while preserving the existing PrettyTables
output.

Changes:
- Add summary line with number of rows and columns
- Display OMOP CDM version when metadata is available
- Ensure output includes "OMOP CDM version: <version>" to match tests
- Keep existing PrettyTables rendering unchanged

Example output:
HealthTable (OMOP v5.4.1): 3 rows × 3 columns
<PrettyTables output>
OMOP CDM version: v5.4.1

Motivation:
Working with large health datasets requires quick visibility of table size
and OMOP version without scanning the full table. This improves usability
while remaining fully backward compatible.

Impact:
- No breaking changes
- Improves developer experience
- Maintains existing workflows
